### PR TITLE
refactor: 로그아웃을 user_id 받는 로직으로 변경

### DIFF
--- a/members/applications/member_service.py
+++ b/members/applications/member_service.py
@@ -48,8 +48,7 @@ class MemberService:
         logout_request_serialzier.is_valid(raise_exception=True)
         logout_data: dict = logout_request_serialzier.validated_data
         
-        refresh_token = logout_data.get('refresh_token')
-        user_id = TokenValidator.get_user_id_from_refresh_token(refresh_token)
+        user_id = logout_data.get('user_id')
         redis_conn: Redis = get_redis_connection(db_select=3)
         redis_conn.delete(user_id)
 

--- a/members/serializers/member_serializer.py
+++ b/members/serializers/member_serializer.py
@@ -33,7 +33,7 @@ class SigninResponseSerializer(serializers.Serializer):
     member = MemberResponseSerializer()
 
 class LogoutRequestSerializer(serializers.Serializer):
-    refreshToken = serializers.CharField(source='refresh_token')
+    userId = serializers.IntegerField(source='user_id')
 
 class RefreshAccessRequestSerialzier(serializers.Serializer):
     refreshToken = serializers.CharField(source='refresh_token')


### PR DESCRIPTION
### 작업한 내용
- 기존 리프레시 토큰에서 user_id를 빼오는 것은 토큰이 만료되면 400이 뜨기 때문에 usre_id를 받는 것으로 변경
- 